### PR TITLE
fix: MyLogger should utilize the PHP error log

### DIFF
--- a/src/MyLogger.php
+++ b/src/MyLogger.php
@@ -6,6 +6,6 @@ include_once('Logger.php');
 
 class MyLogger implements Logger {
     public function log($message) {
-        print("\n" . $message);
+        error_log($message);
     }
 }


### PR DESCRIPTION
Instead of printing status messages (e.g., "retrying in X seconds")  to stdout. Using `error_log()` will prevent it from interfering with the output.